### PR TITLE
Fix crawler performance derp (Array.prototype.shift)

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "aws4": "^1.8.0",
     "dnscache": "github:cloudrac3r/dnscache",
+    "double-ended-queue": "^2.1.0-0",
     "fast-xml-parser": "^3.12.10",
     "mime": "^2.4.0",
     "node-fetch": "^2.3.0",


### PR DESCRIPTION
Deque is INFINITELY FASTER compared to an array when acting as a queue.

This implementation of flatstr is approximately 2x faster than
Buffer.from(s).toString()

body.match(regex) is pretty much the same as regex.exec(body)